### PR TITLE
Drag & drop

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -28,3 +28,7 @@
   text-align: center;
   color: red;
 }
+
+.node:hover {
+  background-color: cornflowerblue;
+}

--- a/js/index.js
+++ b/js/index.js
@@ -28,7 +28,11 @@ function updateTree() {
     })
     .on("end", function(d) {
       if (hoveredNodeId) {
-        whakapapa.moveNode(d.data.extra.id, hoveredNodeId);
+        try {
+          whakapapa.moveNode(d.data.extra.id, hoveredNodeId);
+        } catch (e) {
+          showError(e);
+        }
       }
       d3.select(this).attr("pointer-events", "");
       updateTree();

--- a/js/index.js
+++ b/js/index.js
@@ -38,6 +38,13 @@ function contextMenu(name, extra, id) {
         }
       },
       {
+        text: "Delete",
+        click: function() {
+          deleteNode(extra.id);
+          updateTree();
+        }
+      },
+      {
         text: "Create parent",
         click: function() {
           $("#CreateNodeModalParent").data("nodeId", extra.id);
@@ -119,6 +126,15 @@ function createParent() {
   } catch (e) {
     showError(e);
   }
+}
+
+function deleteNode(nodeId) {
+  // try {
+  whakapapa.deleteNodeById(nodeId);
+  clearError();
+  // } catch (e) {
+  // showError(e);
+  // }
 }
 
 function saveTree() {

--- a/js/index.js
+++ b/js/index.js
@@ -129,12 +129,12 @@ function createParent() {
 }
 
 function deleteNode(nodeId) {
-  // try {
-  whakapapa.deleteNodeById(nodeId);
-  clearError();
-  // } catch (e) {
-  // showError(e);
-  // }
+  try {
+    whakapapa.deleteNodeById(nodeId);
+    clearError();
+  } catch (e) {
+    showError(e);
+  }
 }
 
 function saveTree() {

--- a/js/tree.js
+++ b/js/tree.js
@@ -147,15 +147,31 @@ Tree.prototype.addSibling = function(node, parent, siblingId) {
 };
 
 Tree.prototype.moveNode = function(nodeId, targetId) {
-  console.log(nodeId, targetId);
   var node = this.findNodeById(nodeId);
+  var marriage = this.findMarriageBySpouseId(nodeId);
   var target = this.findNodeById(targetId);
-  this.deleteNodeById(nodeId);
+  var targetSpouse = this.findMarriageBySpouseId(targetId);
 
-  var marriage = this.findMarriageBySpouseId(targetId);
-  if (marriage) {
+  if (!marriage && !this.findParentById(nodeId)) {
+    if (node.marriages.length) {
+      // It's the root node, but there's a spouse so they become the new root node by default.
+      // We just pick the first one in the array.
+      this.tree = node.marriages[0].spouse;
+      this.tree.children = node.marriages[0].children;
+      node.marriages.shift();
+    } else {
+      throw new Error(
+        "Can't move the root node without deleting the tree, sorry! Try adding another parent first?"
+      );
+    }
+  } else {
+    // It's not the root node, we can safely delete
+    this.deleteNodeById(nodeId);
+  }
+
+  if (targetSpouse) {
     // Dropped node on a 'spouse'
-    marriage.children.push(node);
+    targetSpouse.children.push(node);
     return;
   }
 

--- a/js/tree.js
+++ b/js/tree.js
@@ -310,10 +310,11 @@ Tree.prototype.findMarriageBySpouseId = function(needle, nodes) {
   return result;
 };
 
-Tree.prototype.findNodeIn = function(needle, haystack) {
+Tree.prototype.findNodeWith = function(needle, haystack, findFunc) {
   var result = null;
+  var func = findFunc.bind(this);
   for (var i = 0; i < haystack.length; i++) {
-    result = this.findNodeById(needle, haystack[i]);
+    result = func(needle, haystack[i]);
     if (result) {
       return result;
     }
@@ -330,7 +331,7 @@ Tree.prototype.findNodeById = function(needle, nodes) {
     return haystack;
   }
 
-  result = this.findNodeIn(needle, haystack.children);
+  result = this.findNodeWith(needle, haystack.children, this.findNodeById);
   if (result) {
     return result;
   }
@@ -340,7 +341,7 @@ Tree.prototype.findNodeById = function(needle, nodes) {
       result = marriage.spouse;
       return true;
     }
-    result = self.findNodeIn(needle, marriage.children);
+    result = self.findNodeWith(needle, marriage.children, self.findNodeById);
     return !!result;
   });
 
@@ -373,32 +374,15 @@ Tree.prototype.findParentById = function(needle, nodes) {
     return haystack;
   }
 
-  if (haystack.children.length) {
-    haystack.children.some(function(child) {
-      var found = self.findParentById(needle, child);
-      if (found) {
-        result = found;
-        return true;
-      }
-      return false;
-    });
-    if (result) {
-      return result;
-    }
+  result = this.findNodeWith(needle, haystack.children, this.findParentById);
+  if (result) {
+    return result;
   }
 
-  if (haystack.marriages.length) {
-    haystack.marriages.some(function(marriage) {
-      return marriage.children.some(function(child) {
-        var found = self.findParentById(needle, child);
-        if (found) {
-          result = found;
-          return true;
-        }
-        return false;
-      });
-    });
-  }
+  haystack.marriages.some(function(marriage) {
+    result = self.findNodeWith(needle, marriage.children, self.findParentById);
+    return !!result;
+  });
 
   return result;
 };

--- a/js/tree.js
+++ b/js/tree.js
@@ -146,6 +146,28 @@ Tree.prototype.addSibling = function(node, parent, siblingId) {
   parent.children.push(newNode);
 };
 
+Tree.prototype.moveNode = function(nodeId, targetId) {
+  console.log(nodeId, targetId);
+  var node = this.findNodeById(nodeId);
+  var target = this.findNodeById(targetId);
+  this.deleteNodeById(nodeId);
+
+  var marriage = this.findMarriageBySpouseId(targetId);
+  if (marriage) {
+    // Dropped node on a 'spouse'
+    marriage.children.push(node);
+    return;
+  }
+
+  if (target.marriages.length) {
+    // Default behaviour is to add the node to .marriages[0]
+    target.marriages[0].children.push(node);
+    return;
+  }
+
+  target.children.push(node);
+};
+
 Tree.prototype.findPartnerBySpouseId = function(needle, nodes) {
   var result = null;
   var self = this;

--- a/js/tree.js
+++ b/js/tree.js
@@ -226,6 +226,26 @@ Tree.prototype.isEmpty = function() {
   );
 };
 
+Tree.prototype.findNodeInChildren = function(needle, children) {
+  return this.findNodeWith(needle, children, this.findNodeById);
+};
+
+Tree.prototype.findNodeInMarriages = function(needle, marriages) {
+  var result = null;
+  var self = this;
+
+  marriages.some(function(marriage) {
+    if (marriage.spouse.extra.id === needle) {
+      result = marriage.spouse;
+      return true;
+    }
+    result = self.findNodeWith(needle, marriage.children, self.findNodeById);
+    return !!result;
+  });
+
+  return result;
+};
+
 // Refactor away some repetition: call `findFunc` on each element in haystack, returning early if
 // non-null. `findFunc` is expected to call itself recursively from elsewhere on the prototype.
 Tree.prototype.findNodeWith = function(needle, haystack, findFunc) {
@@ -249,21 +269,10 @@ Tree.prototype.findNodeById = function(needle, nodes) {
     return haystack;
   }
 
-  result = this.findNodeWith(needle, haystack.children, this.findNodeById);
-  if (result) {
-    return result;
-  }
-
-  haystack.marriages.some(function(marriage) {
-    if (marriage.spouse.extra.id === needle) {
-      result = marriage.spouse;
-      return true;
-    }
-    result = self.findNodeWith(needle, marriage.children, self.findNodeById);
-    return !!result;
-  });
-
-  return result;
+  return (
+    this.findNodeInChildren(needle, haystack.children) ||
+    this.findNodeInMarriages(needle, haystack.marriages)
+  );
 };
 
 Tree.prototype.findMarriageBySpouseId = function(needle, nodes) {

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -109,6 +109,24 @@ describe("Tree", () => {
       const node = t.findNodeById("12345");
       expect(node).to.equal(null);
     });
+
+    it("finds a node if spouse", () => {
+      const spouse = MANAIA_NODE.marriages[0].spouse;
+      const node = t.findNodeById(spouse.extra.id);
+      expect(node).to.deep.equal(spouse);
+    });
+
+    it("finds a node if in .children", () => {
+      const child = MANAIA_NODE.children[0];
+      const node = t.findNodeById(child.extra.id);
+      expect(node).to.deep.equal(child);
+    });
+
+    it("finds a node if in .marriages", () => {
+      const child = MANAIA_NODE.marriages[0].children[0];
+      const node = t.findNodeById(child.extra.id);
+      expect(node).to.deep.equal(child);
+    });
   });
 
   describe("findMarriageBySpouseId", () => {
@@ -278,6 +296,27 @@ describe("Tree", () => {
     it("renames a node", () => {
       t.renameNodeById(MANAIA_NODE.extra.id, "abcde");
       expect(MANAIA_NODE.name).to.equal("abcde");
+    });
+  });
+
+  describe("deleteNodeById", () => {
+    it("should transfer children from the 'marriage' to .children", () => {
+      var spouseId = MANAIA_NODE.marriages[0].spouse.extra.id;
+      var childId = MANAIA_NODE.marriages[0].children[0].extra.id;
+      t.deleteNodeById(spouseId);
+      expect(MANAIA_NODE.children.find(child => child.extra.id === childId)).to
+        .be.ok;
+    });
+
+    it("should remove the 'marriage'", () => {
+      var spouseId = MANAIA_NODE.marriages[0].spouse.extra.id;
+      t.deleteNodeById(spouseId);
+      expect(MANAIA_NODE.marriages.length).to.equal(0);
+    });
+
+    it("should remove the node", () => {
+      t.deleteNodeById(MANAIA_NODE.children[0].extra.id);
+      expect(MANAIA_NODE.children.length).to.equal(0);
     });
   });
 });

--- a/tests/tree.test.js
+++ b/tests/tree.test.js
@@ -142,6 +142,19 @@ describe("Tree", () => {
     });
   });
 
+  describe("findPartnerBySpouseId", () => {
+    it("finds a partner", () => {
+      const spouseId = MANAIA_NODE.marriages[0].spouse.extra.id;
+      const partner = t.findPartnerBySpouseId(spouseId);
+      expect(partner).to.deep.equal(MANAIA_NODE);
+    });
+
+    it("returns null if not a spouse id", () => {
+      const partner = t.findPartnerBySpouseId(MANAIA_NODE.extra.id);
+      expect(partner).to.be.null;
+    });
+  });
+
   describe("hasChild", () => {
     it("returns true if child in children", () => {
       const childId = MANAIA_NODE.children[0].extra.id;


### PR DESCRIPTION
Well, that was an interesting learning experience! D3's support of drag and drop is not, shall we say, first rate! Dragging is easy, figuring out the drop target took a little more thought.

Anyway, here's the rules:
 - all drags are assumed to be adding children (you can't drag to create a spouse, though I'm sure that's a possibility in the future). It also means if you drag a spouse away from their partnership, the kids don't link to them anymore
 - dragging onto either one of a couple of parents adds the child to the family
 - dragging onto a single parent adds the child into `.children`
 - You can drag the root node as long as there's a spouse. If not, it displays an error.